### PR TITLE
Shunsuke

### DIFF
--- a/indexDP.html
+++ b/indexDP.html
@@ -249,7 +249,10 @@ th {
 <hr>
 <h2>ソフトウェア工学II「樹状整列」開発計画書</h2>
 <div class="belt">
-<h3><a name="KanseiSaseteKudasai">完成させてください</a></h3>
+<h3><a name="Kaihatutaisei">開発体制</a></h3>
+</div>
+<div class="belt">
+<h3><a name="KaihatuSchedule">開発スケジュール</a></h3>
 </div>
 <hr>
 <div class="right-small">Copyright 20xx Project xx, Updated: 2017/03/13 (Created: 2009/11/11)</div>

--- a/indexDP.html
+++ b/indexDP.html
@@ -187,6 +187,9 @@ th {
   padding : 0px 0px;
   vertical-align : middle;
 }
+p {
+  text-indent: 1em;
+}
 #menu {
   margin: 0px 0px 0px 0px;
   padding: 0px;
@@ -251,10 +254,68 @@ th {
 <div class="belt">
 <h3><a name="Kaihatutaisei">開発体制</a></h3>
 </div>
+    <h4>開発に関わるメンバーの一覧とその担当</h4>
+      <table class="content" summary="樹状整列プログラム開発を行うメンバーとその担当">
+        <tbody>
+          <tr>
+            <td align="right">田野中　瞭：</td>
+            <td align="left">プロジェクトマネージャー・プログラマ</td>
+          </tr>
+          <tr>
+            <td align="right">藤山　和紀：</td>
+            <td align="left">プログラマ・テスタ・仕様適合検査の責任者</td>
+          </tr>
+          <tr>
+            <td align="right">畑中　駿助：</td>
+            <td align="left">プログラマ・テスタ</td>
+          </tr>
+          <tr>
+            <td align="right">小田原　史弥：</td>
+            <td align="left">プログラマ・デザイナ</td>
+          </tr>
+        </tbody>
+      </table>
+    <br/>
+    <h4>コンポーネント（部品＝クラス）毎の担当者</h4>
+      <table class="content" summary="開発するコンポーネント（部品＝クラス）毎の担当者">
+        <tbody>
+          <tr>
+            <td align="right">Branch：</td>
+            <td align="left">担当者A</td>
+          </tr>
+          <tr>
+            <td align="right">Constants：</td>
+            <td align="left">担当者B</td>
+          </tr>
+          <tr>
+            <td align="right">Forest：</td>
+            <td align="left">担当者C</td>
+          </tr>
+          <tr>
+            <td align="right">Node：</td>
+            <td align="left">担当者D</td>
+          </tr>
+          <tr>
+            <td align="right">SpiroController：</td>
+            <td align="left">担当者E</td>
+          </tr>
+          <tr>
+            <td align="right">SpiroModel：</td>
+            <td align="left">担当者F</td>
+          </tr>
+          <tr>
+            <td align="right">SpiroView：</td>
+            <td align="left">担当者G</td>
+          </tr>
+        </tbody>
+      </table>
+    <br/>
+    <p>以上のメンバーで開発を行う。基本的に上に示した担当者が責任を持ってそれぞれの開発を行う。しかし、開発途中に何か問題が生じた場合はその限りではない。開発に用いるプログラミング言語はJavaである。また、バージョン管理システムとしてGithubを用いて開発を行い、開発におけるチャットツールとしてSlack、Lineを利用する。仕様通りのプログラムを完成させるために、仕様適合検査の責任者が次項の開発スケジュールに示されたマイルストーンごとに、設計段階から仕様のチェックをクライアント（開発依頼者＝青木淳）と共に行う。開発にあたって不明な点が生じた場合はクライアントと協議して開発を進める。
+    </p>
 <div class="belt">
 <h3><a name="KaihatuSchedule">開発スケジュール</a></h3>
 </div>
 <hr>
-<div class="right-small">Copyright 20xx Project xx, Updated: 2017/03/13 (Created: 2009/11/11)</div>
+<div class="right-small">Copyright 2019 Project TreeAlignment, Updated: 2019/05/12 (Created: 2019/05/12)</div>
 </body>
 </html>


### PR DESCRIPTION
開発計画書の開発体制の編集を行いました。
開発体制としてメンバーの一覧と担当を明記し、開発体制の説明を書きました。
また、190〜192行目に、段落のタグpを用いて文章を書く際に、最初に全角一文字分のスペースを入れる処理を追加しました。